### PR TITLE
Kernelspec metadata

### DIFF
--- a/example/groovy/build.gradle
+++ b/example/groovy/build.gradle
@@ -13,6 +13,8 @@ jupyter {
     kernelEnv IN_JUPYTER_KERNEL: '1'
     kernelEnv['KERNEL_VERSION'] = project.version
 
+    kernelMetadata['debugger'] = true
+
     kernelResources {
         from 'kernel' // This is the default
 

--- a/example/kotlin/build.gradle.kts
+++ b/example/kotlin/build.gradle.kts
@@ -15,6 +15,8 @@ jupyter {
 
     kernelEnv["IN_JUPYTER_KERNEL"] = "1"
 
+    kernelMetadata["debugger"] = true
+
     kernelResources {
         from("kernel") // This is the default if `kernelResources` is not specified
 

--- a/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/JupyterKernelInstallerPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/JupyterKernelInstallerPlugin.kt
@@ -54,6 +54,8 @@ class JupyterKernelInstallerPlugin : Plugin<Project> {
 
             installSpec.kernelEnv.convention(kernelExtension.kernelEnv)
 
+            installSpec.kernelMetadata.convention(kernelExtension.kernelMetadata)
+
             installSpec.kernelExecutable.convention(kernelExtension.kernelExecutable)
 
             installSpec.kernelResources.setFrom(kernelExtension.kernelResources)

--- a/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/KernelExtension.kt
+++ b/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/KernelExtension.kt
@@ -39,14 +39,19 @@ import org.gradle.api.tasks.AbstractCopyTask
 import org.gradle.api.tasks.TaskProvider
 import javax.inject.Inject
 
-open class KernelExtension @Inject constructor(private val project: Project, objects: ObjectFactory) : WithGradleDslExtensions {
+open class KernelExtension @Inject constructor(private val project: Project, objects: ObjectFactory) :
+    WithGradleDslExtensions {
     val kernelName: Property<String> = objects.property(String::class.java).convention(project.name)
     val kernelDisplayName: Property<String> = objects.property(String::class.java).convention(kernelName)
     val kernelLanguage: Property<String> = objects.property(String::class.java).convention(kernelName)
 
     val kernelInterruptMode: Property<String> = objects.property(String::class.java).convention("message")
 
-    val kernelEnv: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java).convention(mutableMapOf())
+    val kernelEnv: MapProperty<String, String> =
+        objects.mapProperty(String::class.java, String::class.java).convention(mutableMapOf())
+
+    val kernelMetadata: MapProperty<String, Any> =
+        objects.mapProperty(String::class.java, Any::class.java).convention(mutableMapOf())
 
     val kernelExecutable: RegularFileProperty = objects.fileProperty()
 
@@ -61,18 +66,24 @@ open class KernelExtension @Inject constructor(private val project: Project, obj
     fun kernelInterruptMode(kernelInterruptMode: String?) = this.kernelInterruptMode.set(kernelInterruptMode)
 
     fun kernelEnv(kernelEnv: Map<String, String>) = this.kernelEnv.putAll(kernelEnv)
-    fun kernelEnv(configure: Action<in MutableMap<String, String>>) = this.kernelEnv.set(this.kernelEnv.get().also(configure::execute))
+    fun kernelEnv(configure: Action<in MutableMap<String, String>>) =
+        this.kernelEnv.set(this.kernelEnv.get().also(configure::execute))
+
+    fun kernelMetadata(kernelMetadata: Map<String, Any>) = this.kernelMetadata.putAll(kernelMetadata)
+    fun kernelMetadata(configure: Action<in MutableMap<String, Any>>) =
+        this.kernelMetadata.set(this.kernelMetadata.get().also(configure::execute))
 
     fun kernelExecutable(kernelExecutable: RegularFile) = this.kernelExecutable.set(kernelExecutable)
     fun kernelExecutable(kernelExecutable: Any) = this.kernelExecutable.set(project.file(kernelExecutable))
     fun setKernelExecutable(kernelExecutable: RegularFile) = this.kernelExecutable.set(kernelExecutable)
 
     fun kernelResources(configure: Action<in CopySourceSpec>) {
-        val provider = project.tasks.named(STAGE_EXTRA_KERNEL_RESOURCES_TASK_NAME, AbstractCopyTask::class.java) { task ->
-            val spec = project.copySpec()
-            configure.execute(spec)
-            task.with(spec)
-        }
+        val provider =
+            project.tasks.named(STAGE_EXTRA_KERNEL_RESOURCES_TASK_NAME, AbstractCopyTask::class.java) { task ->
+                val spec = project.copySpec()
+                configure.execute(spec)
+                task.with(spec)
+            }
         kernelResources(provider)
     }
 

--- a/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/KernelInstallSpec.kt
+++ b/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/KernelInstallSpec.kt
@@ -51,6 +51,9 @@ abstract class KernelInstallSpec {
     @get:Input
     abstract val kernelEnv: MapProperty<String, String>
 
+    @get:Input
+    abstract val kernelMetadata: MapProperty<String, Any>
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NAME_ONLY)
     abstract val kernelExecutable: RegularFileProperty

--- a/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/tasks/GenerateKernelJsonTask.kt
+++ b/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/tasks/GenerateKernelJsonTask.kt
@@ -67,11 +67,12 @@ abstract class GenerateKernelJsonTask : DefaultTask(), WithGradleDslExtensions {
     fun execute() {
         val spec = with(kernelInstallSpec) {
             KernelJson(
-                    "${UNSET_PATH_TOKEN}/${kernelExecutable.get().asFile.name}",
-                    kernelDisplayName.get(),
-                    kernelLanguage.get(),
-                    kernelInterruptMode.get(),
-                    kernelEnv.get()
+                "${UNSET_PATH_TOKEN}/${kernelExecutable.get().asFile.name}",
+                kernelDisplayName.get(),
+                kernelLanguage.get(),
+                kernelInterruptMode.get(),
+                kernelEnv.get(),
+                kernelMetadata.get(),
             )
         }
         output.get().asFile.writeText(spec.toString(), Charsets.UTF_8)

--- a/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/tasks/InstallKernelTask.kt
+++ b/plugin/src/main/kotlin/io/github/spencerpark/jupyter/gradle/tasks/InstallKernelTask.kt
@@ -332,7 +332,8 @@ abstract class InstallKernelTask @Inject constructor(private val execOps: ExecOp
                 kernelDisplayName.get(),
                 kernelLanguage.get(),
                 kernelInterruptMode.get(),
-                env
+                env,
+                kernelMetadata.get(),
             )
         }
     }


### PR DESCRIPTION
Allow configuring the `metadata` field statically for the generated `kernel.json`. In particular this field is used to declare that a kernel supports debugging but it is open ended to provide options used by clients.

Not sure if it is useful to configure during install like environment variables but for now keeping it simple.

Map values try to roughly map standard primitive and collections to their json equivalents. Build scripts can explicitly create `JsonElement`s and put them in the map if desired but using plain values should just work as expected.

```kotlin
private fun json(value: Any?): JsonElement {
    return when (value) {
        is JsonElement -> value
        null -> JsonNull
        is String -> JsonPrimitive(value)
        is Number -> JsonPrimitive(value)
        is Boolean -> JsonPrimitive(value)
        is Map<*, *> -> JsonObject(value.entries.associate { it.key.toString() to json(it.value) })
        is List<*> -> JsonArray(value.map { json(it) }.toList())
        else -> throw IllegalArgumentException("Cannot encode json value: $value")
    }
}
```